### PR TITLE
fix two package conflicts in trajectory notebook

### DIFF
--- a/TrajectoryAnalysisTutorial_GitHub.ipynb
+++ b/TrajectoryAnalysisTutorial_GitHub.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install numpy==1.21.6 pandas==1.3.5 matplotlib===3.5.0 scanpy==1.9.1 igraph==0.9.8 scvelo==0.2.4 loompy==3.0.6 anndata==0.8.0"
+    "!pip install numpy==1.23 pandas==1.3.5 matplotlib==3.5.0 scanpy==1.9.1 igraph==0.9.8 scvelo==0.2.4 loompy==3.0.6 anndata==0.8.0"
    ]
   },
   {


### PR DESCRIPTION
In the pip install instructions, change numpy version to 1.23 and remove extra = from matplotlib.