### PR TITLE
updated trajectory analysis ipynb with latest package versions

### DIFF
--- a/TrajectoryAnalysisTutorial_GitHub.ipynb
+++ b/TrajectoryAnalysisTutorial_GitHub.ipynb
@@ -1,408 +1,471 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "1dc3bd23",
-   "metadata": {},
-   "source": [
-    "# Trajectory Analysis using 10x Single Cell Gene Expression Data\n",
-    "More details on this analysis can be found in the 10x Genomics Analysis Guides tutorial, located here: https://www.10xgenomics.com/resources/analysis-guides/trajectory-analysis-using-10x-Genomics-single-cell-gene-expression-data"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "1dc3bd23",
+      "metadata": {
+        "id": "1dc3bd23"
+      },
+      "source": [
+        "# Trajectory Analysis using 10x Single Cell Gene Expression Data\n",
+        "More details on this analysis can be found in the 10x Genomics Analysis Guides tutorial, located here: https://www.10xgenomics.com/resources/analysis-guides/trajectory-analysis-using-10x-Genomics-single-cell-gene-expression-data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1e026de3",
+      "metadata": {
+        "id": "1e026de3"
+      },
+      "source": [
+        "Updated: March 14, 2025"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "79da6e17",
+      "metadata": {
+        "id": "79da6e17"
+      },
+      "source": [
+        "This will install the required Python library packages needed for this tutorial:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "346184d0",
+      "metadata": {
+        "id": "346184d0"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install numpy==2.2.6 pandas==2.3.1 matplotlib==3.10.5 scanpy==1.11.4 igraph==0.11.9 scvelo==0.3.3 loompy==3.0.8 anndata==0.12.2 contourpy==1.3.3 numba==0.61.2"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b1c03f27",
+      "metadata": {
+        "id": "b1c03f27"
+      },
+      "source": [
+        "This will create a new directory called \"input-files\", then download and extract several input data files needed for this tutorial, then display the list of files now available."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "833d83cc",
+      "metadata": {
+        "id": "833d83cc"
+      },
+      "outputs": [],
+      "source": [
+        "!mkdir input-files\n",
+        "!curl -o input-files/filtered_feature_bc_matrix.tar.gz https://cf.10xgenomics.com/supp/cell-exp/neutrophils/filtered_feature_bc_matrix.tar.gz\n",
+        "!curl -o input-files/WB_Lysis_3p_Introns_8kCells.loom https://cf.10xgenomics.com/supp/cell-exp/neutrophils/WB_Lysis_3p_Introns_8kCells.loom\n",
+        "!curl -o input-files/3p-Neutrophils-clusters.csv https://cf.10xgenomics.com/supp/cell-exp/neutrophils/3p-Neutrophils-clusters.csv\n",
+        "!curl -o input-files/3p-Neutrophils-UMAP-Projection.csv https://cf.10xgenomics.com/supp/cell-exp/neutrophils/3p-Neutrophils-UMAP-Projection.csv\n",
+        "!tar -xvzf input-files/filtered_feature_bc_matrix.tar.gz -C input-files/\n",
+        "!ls -lah input-files"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b605db86",
+      "metadata": {
+        "id": "b605db86"
+      },
+      "outputs": [],
+      "source": [
+        "# First, import required packages in the current session.\n",
+        "\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import matplotlib.pyplot as pl\n",
+        "import scanpy as sc\n",
+        "import igraph\n",
+        "import scvelo as scv\n",
+        "import loompy as lmp\n",
+        "import anndata as ad\n",
+        "\n",
+        "import warnings\n",
+        "warnings.filterwarnings('ignore')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cb39697d",
+      "metadata": {
+        "id": "cb39697d"
+      },
+      "source": [
+        "* The scvelo tool only calculates velocity\n",
+        "* Now we need anchors for visualization\n",
+        "* UMAP gives us projections\n",
+        "* barcode assignments are associated with different clusters\n",
+        "* UMAP + clusters come from Loupe\n",
+        "\n",
+        "Let's import the 2 files from Loupe."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8a0ba395",
+      "metadata": {
+        "id": "8a0ba395"
+      },
+      "outputs": [],
+      "source": [
+        "# Read in the subset of clusters exported from Loupe Browser\n",
+        "Clusters_Loupe = pd.read_csv(\"./input-files/3p-Neutrophils-clusters.csv\", delimiter=',',index_col=0)\n",
+        "\n",
+        "# Create list with only Neutrophil Barcodes\n",
+        "# This will be used later to subset the count matrix\n",
+        "Neutrophils_BCs = Clusters_Loupe.index"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e8c259db",
+      "metadata": {
+        "id": "e8c259db"
+      },
+      "outputs": [],
+      "source": [
+        "# Read UMAP exported from Loupe Browser\n",
+        "UMAP_Loupe = pd.read_csv(\"./input-files/3p-Neutrophils-UMAP-Projection.csv\", delimiter=',',index_col=0)\n",
+        "\n",
+        "# Tansform to Numpy (for formatting)\n",
+        "UMAP_Loupe = UMAP_Loupe.to_numpy()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c88d565a",
+      "metadata": {
+        "id": "c88d565a"
+      },
+      "source": [
+        "Now we will import the GEX matrix.\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "1eb7f657",
+      "metadata": {
+        "scrolled": true,
+        "id": "1eb7f657"
+      },
+      "outputs": [],
+      "source": [
+        "# Define Path to cellranger output\n",
+        "Path10x='./input-files/filtered_feature_bc_matrix/'\n",
+        "\n",
+        "# Read filtered feature bc matrix output from cellranger count\n",
+        "Neutro3p = sc.read_10x_mtx(Path10x,var_names='gene_symbols',cache=True)\n",
+        "Neutro3p"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8ac71801",
+      "metadata": {
+        "id": "8ac71801"
+      },
+      "outputs": [],
+      "source": [
+        "# These are the barcodes (n_obs) = 8000\n",
+        "# This is the number set in --force-cells\n",
+        "Neutro3p.obs"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "46e6fbfa",
+      "metadata": {
+        "id": "46e6fbfa"
+      },
+      "outputs": [],
+      "source": [
+        "# These are the gene_ids (n_vars) = 36,601\n",
+        "Neutro3p.var_names"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "eda2e59e",
+      "metadata": {
+        "id": "eda2e59e"
+      },
+      "outputs": [],
+      "source": [
+        "Neutro3p_df = Neutro3p.to_df()\n",
+        "Neutro3p_df.head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "df4b7d06",
+      "metadata": {
+        "id": "df4b7d06"
+      },
+      "source": [
+        "The earlier matrix was the full dataset.\n",
+        "But we are only interested in neutrophils. So, we need to subset the matrix into only neutrophils\n",
+        "First, we need to define which barcodes are associated with which cluster"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a7bf1e9e",
+      "metadata": {
+        "id": "a7bf1e9e"
+      },
+      "outputs": [],
+      "source": [
+        "# Filter Cells to only Neutrophils\n",
+        "Neutro3p = Neutro3p[Neutrophils_BCs]\n",
+        "\n",
+        "# Add Clusters from Loupe to object\n",
+        "Neutro3p.obs['Loupe'] = Clusters_Loupe\n",
+        "\n",
+        "# Add UMAP from Loupe to object\n",
+        "Neutro3p.obsm[\"X_umap\"] = UMAP_Loupe"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a0240369",
+      "metadata": {
+        "id": "a0240369"
+      },
+      "source": [
+        "Next, read velocyto output and merge"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f6fee80a",
+      "metadata": {
+        "id": "f6fee80a"
+      },
+      "outputs": [],
+      "source": [
+        "# Read velocyto output\n",
+        "VelNeutro3p = ad.read_loom('./input-files/WB_Lysis_3p_Introns_8kCells.loom')\n",
+        "\n",
+        "# Merge velocyto and cellranger outputs\n",
+        "Neutro3p = scv.utils.merge(Neutro3p, VelNeutro3p)\n",
+        "\n",
+        "Neutro3p"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "540b1436",
+      "metadata": {
+        "id": "540b1436"
+      },
+      "source": [
+        "You might get this warning, but no need to worry:\n",
+        "> Variable names are not unique. To make them unique, call `.var_names_make_unique`.\n",
+        "\n",
+        "Next, process dataset and obtain latent time values for each cell\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7a6e8fff",
+      "metadata": {
+        "id": "7a6e8fff"
+      },
+      "outputs": [],
+      "source": [
+        "# Standard scvelo processing to run Dynamical Mode\n",
+        "scv.pp.filter_and_normalize(Neutro3p, min_shared_counts=30, n_top_genes=2000)\n",
+        "scv.pp.moments(Neutro3p, n_pcs=30, n_neighbors=30)\n",
+        "\n",
+        "scv.tl.recover_dynamics(Neutro3p)\n",
+        "scv.tl.velocity(Neutro3p, mode='dynamical')\n",
+        "scv.tl.velocity_graph(Neutro3p)\n",
+        "scv.tl.recover_latent_time(Neutro3p)\n",
+        "\n",
+        "Neutro3p"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5ba648d4",
+      "metadata": {
+        "id": "5ba648d4"
+      },
+      "outputs": [],
+      "source": [
+        "# velocity plo\n",
+        "# default plotting parameters\n",
+        "scv.pl.velocity_embedding_stream(Neutro3p,basis=\"umap\",color=\"Loupe\",title='Neutrophils',fontsize=20,legend_fontsize=20,min_mass=2,save='scVelo-umap-cluster.png')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "11fa9489",
+      "metadata": {
+        "id": "11fa9489"
+      },
+      "outputs": [],
+      "source": [
+        "scv.pl.velocity_embedding_stream(Neutro3p,basis=\"umap\",color=\"latent_time\",title='Neutrophils',fontsize=20,legend_fontsize=20,min_mass=2,color_map=\"plasma\",save='scVelo-umap-latent_time.png')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "16261baf",
+      "metadata": {
+        "id": "16261baf"
+      },
+      "outputs": [],
+      "source": [
+        "Genes=[\"RETN\",\"LTF\",\"CAMP\",\"ACTB\",\"GCA\",\"LCN2\",\n",
+        "         \"S100A8\",\"MYL6\",\"S100A9\",\"FCGR3B\",\"S100A11\",\"FTH1\",\"IFIT1\",\n",
+        "         \"IFITM3\",\"IFIT3\",\"ISG15\",\"IFIT2\",\"RPS9\",\"NEAT1\",\"MALAT1\",\"NFKBIA\",\"CXCL8\"]\n",
+        "scv.pl.heatmap(Neutro3p, var_names=Genes, sortby='latent_time', col_color='Loupe', n_convolve=100,figsize=(16,8),yticklabels=True,sort=True,colorbar=True,show=True,layer=\"count\", save='scVelo-heatmap-latent_time.png')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e570daf8",
+      "metadata": {
+        "id": "e570daf8"
+      },
+      "outputs": [],
+      "source": [
+        "sc.pl.violin(Neutro3p, keys='latent_time',groupby=\"Loupe\",order=[\"Cluster 4\",\"Cluster 1\",\"Cluster 5\",\"Cluster 6\",\"Cluster 7\",\"Cluster 3\",\"Cluster 2\"], save='scVelo-violin-latent_time.png')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "73c4d6d6",
+      "metadata": {
+        "id": "73c4d6d6"
+      },
+      "source": [
+        "This chunk of code below is used to customize colors for the cluster and plot sizes"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5bc6705f",
+      "metadata": {
+        "id": "5bc6705f"
+      },
+      "outputs": [],
+      "source": [
+        "# Customize parameters for plots (Size, Color, etc)\n",
+        "# let's set these to improve our plots\n",
+        "scv.set_figure_params(style=\"scvelo\")\n",
+        "pl.rcParams[\"figure.figsize\"] = (10,10)\n",
+        "Colorss=[\"#E41A1C\",\"#377EB8\",\"#4DAF4A\",\"#984EA3\",\"#FF7F00\",\"#FFFF33\",\"#A65628\",\"#F781BF\"]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "66386244",
+      "metadata": {
+        "id": "66386244"
+      },
+      "outputs": [],
+      "source": [
+        "scv.pl.velocity_embedding_stream(Neutro3p,basis=\"umap\",color=\"Loupe\",title='Neutrophils',fontsize=20,legend_fontsize=20,min_mass=2,palette=Colorss,save='scVelo-umap-cluster.png')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cb6cafed",
+      "metadata": {
+        "id": "cb6cafed"
+      },
+      "outputs": [],
+      "source": [
+        "scv.pl.velocity_embedding_stream(Neutro3p,basis=\"umap\",color=\"latent_time\",title='Neutrophils',fontsize=20,legend_fontsize=20,min_mass=2,color_map=\"plasma\",save='scVelo-umap-latent_time.png')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f6e394d0",
+      "metadata": {
+        "id": "f6e394d0"
+      },
+      "outputs": [],
+      "source": [
+        "scv.pl.heatmap(Neutro3p, var_names=Genes, sortby='latent_time', col_color='Loupe', n_convolve=100,figsize=(8,6),yticklabels=True,sort=True,colorbar=True,show=True,layer=\"count\", save='scVelo-heatmap-latent_time.png')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8f3ba995",
+      "metadata": {
+        "id": "8f3ba995"
+      },
+      "outputs": [],
+      "source": [
+        "sc.pl.violin(Neutro3p, keys='latent_time',groupby=\"Loupe\",order=[\"Cluster 4\",\"Cluster 1\",\"Cluster 5\",\"Cluster 6\",\"Cluster 7\",\"Cluster 3\",\"Cluster 2\"], save='scVelo-violin-latent_time.png')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "315a3dc4",
+      "metadata": {
+        "id": "315a3dc4"
+      },
+      "source": [
+        "For additional information on analysis using this [10x neutrophils dataset](https://www.10xgenomics.com/resources/datasets/whole-blood-rbc-lysis-for-pbmcs-neutrophils-granulocytes-3-3-1-standard), please see this Tech Note, [Neutrophil Analysis in 10x Genomics Single Cell Gene Expression Assays](https://www.10xgenomics.com/support/single-cell-gene-expression/documentation/steps/sample-prep/neutrophil-analysis-in-10-x-genomics-single-cell-gene-expression-assays)"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.0"
+    },
+    "colab": {
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "1e026de3",
-   "metadata": {},
-   "source": [
-    "Updated: March 14, 2025"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "79da6e17",
-   "metadata": {},
-   "source": [
-    "This will install the required Python library packages needed for this tutorial:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "346184d0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install numpy==1.23.2 pandas==1.5.3 matplotlib==3.6.0 scanpy==1.9.1 igraph==0.9.8 scvelo==0.2.4 loompy==3.0.6 anndata==0.8.0"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b1c03f27",
-   "metadata": {},
-   "source": [
-    "This will create a new directory called \"input-files\", then download and extract several input data files needed for this tutorial, then display the list of files now available."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "833d83cc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!mkdir input-files\n",
-    "!curl -o input-files/filtered_feature_bc_matrix.tar.gz https://cf.10xgenomics.com/supp/cell-exp/neutrophils/filtered_feature_bc_matrix.tar.gz\n",
-    "!curl -o input-files/WB_Lysis_3p_Introns_8kCells.loom https://cf.10xgenomics.com/supp/cell-exp/neutrophils/WB_Lysis_3p_Introns_8kCells.loom\n",
-    "!curl -o input-files/3p-Neutrophils-clusters.csv https://cf.10xgenomics.com/supp/cell-exp/neutrophils/3p-Neutrophils-clusters.csv\n",
-    "!curl -o input-files/3p-Neutrophils-UMAP-Projection.csv https://cf.10xgenomics.com/supp/cell-exp/neutrophils/3p-Neutrophils-UMAP-Projection.csv\n",
-    "!tar -xvzf input-files/filtered_feature_bc_matrix.tar.gz -C input-files/\n",
-    "!ls -lah input-files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b605db86",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# First, import required packages in the current session.\n",
-    "\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import matplotlib.pyplot as pl\n",
-    "import scanpy as sc\n",
-    "import igraph\n",
-    "import scvelo as scv\n",
-    "import loompy as lmp\n",
-    "import anndata\n",
-    "\n",
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cb39697d",
-   "metadata": {},
-   "source": [
-    "* The scvelo tool only calculates velocity\n",
-    "* Now we need anchors for visualization\n",
-    "* UMAP gives us projections\n",
-    "* barcode assignments are associated with different clusters\n",
-    "* UMAP + clusters come from Loupe\n",
-    "\n",
-    "Let's import the 2 files from Loupe."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8a0ba395",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Read in the subset of clusters exported from Loupe Browser\n",
-    "Clusters_Loupe = pd.read_csv(\"./input-files/3p-Neutrophils-clusters.csv\", delimiter=',',index_col=0)\n",
-    "\n",
-    "# Create list with only Neutrophil Barcodes\n",
-    "# This will be used later to subset the count matrix\n",
-    "Neutrophils_BCs = Clusters_Loupe.index"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e8c259db",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Read UMAP exported from Loupe Browser \n",
-    "UMAP_Loupe = pd.read_csv(\"./input-files/3p-Neutrophils-UMAP-Projection.csv\", delimiter=',',index_col=0)\n",
-    "\n",
-    "# Tansform to Numpy (for formatting)\n",
-    "UMAP_Loupe = UMAP_Loupe.to_numpy()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c88d565a",
-   "metadata": {},
-   "source": [
-    "Now we will import the GEX matrix.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1eb7f657",
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# Define Path to cellranger output\n",
-    "Path10x='./input-files/filtered_feature_bc_matrix/'\n",
-    "\n",
-    "# Read filtered feature bc matrix output from cellranger count\n",
-    "Neutro3p = sc.read_10x_mtx(Path10x,var_names='gene_symbols',cache=True)\n",
-    "Neutro3p"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8ac71801",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# These are the barcodes (n_obs) = 8000\n",
-    "# This is the number set in --force-cells\n",
-    "Neutro3p.obs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "46e6fbfa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# These are the gene_ids (n_vars) = 36,601\n",
-    "Neutro3p.var_names"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eda2e59e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Neutro3p_df = Neutro3p.to_df()\n",
-    "Neutro3p_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "df4b7d06",
-   "metadata": {},
-   "source": [
-    "The earlier matrix was the full dataset. \n",
-    "But we are only interested in neutrophils. So, we need to subset the matrix into only neutrophils\n",
-    "First, we need to define which barcodes are associated with which cluster "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a7bf1e9e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Filter Cells to only Neutrophils\n",
-    "Neutro3p = Neutro3p[Neutrophils_BCs]\n",
-    "\n",
-    "# Add Clusters from Loupe to object\n",
-    "Neutro3p.obs['Loupe'] = Clusters_Loupe\n",
-    "\n",
-    "# Add UMAP from Loupe to object\n",
-    "Neutro3p.obsm[\"X_umap\"] = UMAP_Loupe"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a0240369",
-   "metadata": {},
-   "source": [
-    "You might get this warning below, but nothing to worry about.\n",
-    "> Trying to set attribute `.obs` of view, copying.\n",
-    "\n",
-    "Next, read velocyto output and merge"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f6fee80a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Read velocyto output\n",
-    "VelNeutro3p = scv.read('./input-files/WB_Lysis_3p_Introns_8kCells.loom', cache=True)\n",
-    "\n",
-    "# Merge velocyto and cellranger outputs\n",
-    "Neutro3p = scv.utils.merge(Neutro3p, VelNeutro3p)\n",
-    "\n",
-    "Neutro3p"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "540b1436",
-   "metadata": {},
-   "source": [
-    "You might get this warning, but no need to worry:\n",
-    "> Variable names are not unique. To make them unique, call `.var_names_make_unique`.\n",
-    "\n",
-    "Next, process dataset and obtain latent time values for each cell\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7a6e8fff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Standard scvelo processing to run Dynamical Mode\n",
-    "scv.pp.filter_and_normalize(Neutro3p, min_shared_counts=30, n_top_genes=2000)\n",
-    "scv.pp.moments(Neutro3p, n_pcs=30, n_neighbors=30)\n",
-    "\n",
-    "scv.tl.recover_dynamics(Neutro3p)\n",
-    "scv.tl.velocity(Neutro3p, mode='dynamical')\n",
-    "scv.tl.velocity_graph(Neutro3p)\n",
-    "scv.tl.recover_latent_time(Neutro3p)\n",
-    "\n",
-    "Neutro3p"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5ba648d4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# velocity plo\n",
-    "# default plotting parameters\n",
-    "scv.pl.velocity_embedding_stream(Neutro3p,basis=\"umap\",color=\"Loupe\",title='Neutrophils',fontsize=20,legend_fontsize=20,min_mass=2,save='scVelo-umap-cluster.png')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11fa9489",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scv.pl.velocity_embedding_stream(Neutro3p,basis=\"umap\",color=\"latent_time\",title='Neutrophils',fontsize=20,legend_fontsize=20,min_mass=2,color_map=\"plasma\",save='scVelo-umap-latent_time.png')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16261baf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Genes=[\"RETN\",\"LTF\",\"CAMP\",\"ACTB\",\"GCA\",\"LCN2\",\n",
-    "         \"S100A8\",\"MYL6\",\"S100A9\",\"FCGR3B\",\"S100A11\",\"FTH1\",\"IFIT1\",\n",
-    "         \"IFITM3\",\"IFIT3\",\"ISG15\",\"IFIT2\",\"RPS9\",\"NEAT1\",\"MALAT1\",\"NFKBIA\",\"CXCL8\"]\n",
-    "scv.pl.heatmap(Neutro3p, var_names=Genes, sortby='latent_time', col_color='Loupe', n_convolve=100,figsize=(16,8),yticklabels=True,sort=True,colorbar=True,show=True,layer=\"count\", save='scVelo-heatmap-latent_time.png')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e570daf8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc.pl.violin(Neutro3p, keys='latent_time',groupby=\"Loupe\",order=[\"Cluster 4\",\"Cluster 1\",\"Cluster 5\",\"Cluster 6\",\"Cluster 7\",\"Cluster 3\",\"Cluster 2\"], save='scVelo-violin-latent_time.png')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "73c4d6d6",
-   "metadata": {},
-   "source": [
-    "This chunk of code below is used to customize colors for the cluster and plot sizes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5bc6705f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Customize parameters for plots (Size, Color, etc)\n",
-    "# let's set these to improve our plots  \n",
-    "scv.set_figure_params(style=\"scvelo\")\n",
-    "pl.rcParams[\"figure.figsize\"] = (10,10)\n",
-    "Colorss=[\"#E41A1C\",\"#377EB8\",\"#4DAF4A\",\"#984EA3\",\"#FF7F00\",\"#FFFF33\",\"#A65628\",\"#F781BF\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "66386244",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scv.pl.velocity_embedding_stream(Neutro3p,basis=\"umap\",color=\"Loupe\",title='Neutrophils',fontsize=20,legend_fontsize=20,min_mass=2,palette=Colorss,save='scVelo-umap-cluster.png')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cb6cafed",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scv.pl.velocity_embedding_stream(Neutro3p,basis=\"umap\",color=\"latent_time\",title='Neutrophils',fontsize=20,legend_fontsize=20,min_mass=2,color_map=\"plasma\",save='scVelo-umap-latent_time.png')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f6e394d0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scv.pl.heatmap(Neutro3p, var_names=Genes, sortby='latent_time', col_color='Loupe', n_convolve=100,figsize=(8,6),yticklabels=True,sort=True,colorbar=True,show=True,layer=\"count\", save='scVelo-heatmap-latent_time.png')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8f3ba995",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sc.pl.violin(Neutro3p, keys='latent_time',groupby=\"Loupe\",order=[\"Cluster 4\",\"Cluster 1\",\"Cluster 5\",\"Cluster 6\",\"Cluster 7\",\"Cluster 3\",\"Cluster 2\"], save='scVelo-violin-latent_time.png')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "315a3dc4",
-   "metadata": {},
-   "source": [
-    "For additional information on analysis using this [10x neutrophils dataset](https://www.10xgenomics.com/resources/datasets/whole-blood-rbc-lysis-for-pbmcs-neutrophils-granulocytes-3-3-1-standard), please see this Tech Note, [Neutrophil Analysis in 10x Genomics Single Cell Gene Expression Assays](https://www.10xgenomics.com/support/single-cell-gene-expression/documentation/steps/sample-prep/neutrophil-analysis-in-10-x-genomics-single-cell-gene-expression-assays)"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.0"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
Previous analysis notebook was breaking due to version dependency errors. The error messages seemed to be dependent on numpy, likely due to [numpy v2 upgrade in 2024](https://numpy.org/devdocs/release/2.0.0-notes.html). Many package dependencies have subsequently updated to numpy v2.

This list of dependencies now works:

```
!pip install numpy==2.2.6 pandas==2.3.1 matplotlib==3.10.5 scanpy==1.11.4 igraph==0.11.9 scvelo==0.3.3 loompy==3.0.8 anndata==0.12.2 contourpy==1.3.3 numba==0.61.2
```

Additional change was made, scanpy now requires [anndata read_loom function](https://anndata.readthedocs.io/en/latest/generated/anndata.io.read_loom.html).

