### PR TITLE
Update TrajectoryAnalysisTutorial_GitHub.ipynb

### DIFF
--- a/TrajectoryAnalysisTutorial_GitHub.ipynb
+++ b/TrajectoryAnalysisTutorial_GitHub.ipynb
@@ -32,7 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install numpy==1.23.2 pandas==1.5.3 matplotlib==3.6.0 scanpy==1.9.1 igraph==0.9.8 scvelo==0.2.4 loompy==3.0.6 anndata==0.8.0"
+    "!pip install numpy==2.2.6 pandas==2.3.1 matplotlib==3.10.5 scanpy==1.11.4 igraph==0.11.9 scvelo==0.3.3 loompy==3.0.8 anndata==0.12.2 contourpy==1.3.3 numba==0.61.2"
    ]
   },
   {
@@ -75,7 +75,7 @@
     "import igraph\n",
     "import scvelo as scv\n",
     "import loompy as lmp\n",
-    "import anndata\n",
+    "import anndata as ad\n",
     "\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore')"
@@ -216,9 +216,6 @@
    "id": "a0240369",
    "metadata": {},
    "source": [
-    "You might get this warning below, but nothing to worry about.\n",
-    "> Trying to set attribute `.obs` of view, copying.\n",
-    "\n",
     "Next, read velocyto output and merge"
    ]
   },
@@ -230,7 +227,7 @@
    "outputs": [],
    "source": [
     "# Read velocyto output\n",
-    "VelNeutro3p = scv.read('./input-files/WB_Lysis_3p_Introns_8kCells.loom', cache=True)\n",
+    "VelNeutro3p = ad.read_loom('./input-files/WB_Lysis_3p_Introns_8kCells.loom')('./input-files/WB_Lysis_3p_Introns_8kCells.loom')\n",
     "\n",
     "# Merge velocyto and cellranger outputs\n",
     "Neutro3p = scv.utils.merge(Neutro3p, VelNeutro3p)\n",


### PR DESCRIPTION
Previous analysis notebook was breaking due to version dependency errors. The error messages seemed to be dependent on numpy, likely due to [numpy v2 upgrade in 2024](https://numpy.org/devdocs/release/2.0.0-notes.html). Many package dependencies have subsequently updated to numpy v2.

This list of dependencies now works:
```
!pip install numpy==2.2.6 pandas==2.3.1 matplotlib==3.10.5 scanpy==1.11.4 igraph==0.11.9 scvelo==0.3.3 loompy==3.0.8 anndata==0.12.2 contourpy==1.3.3 numba==0.61.2 
```
Additional change was made, scanpy now requires [anndata read_loom function](https://anndata.readthedocs.io/en/latest/generated/anndata.io.read_loom.html).